### PR TITLE
Add default ISSUE_TEMPLATES for our organization

### DIFF
--- a/.github/ISSUE_TEMPLATES/bug_report.md
+++ b/.github/ISSUE_TEMPLATES/bug_report.md
@@ -1,0 +1,36 @@
+---
+name: Bug report
+about: Create a report to help us improve
+labels: bug, triage
+
+---
+
+<!-- Please read our Code of Conduct: https://github.com/deephaven/deephaven-core/blob/main/CODE_OF_CONDUCT.md -->
+<!-- Please search existing issues to avoid creating duplicates. -->
+
+**Description**
+
+A clear and concise description of what the bug is.
+
+**Steps to reproduce**
+1. Go to '...'
+2. Click on '....'
+3. Scroll down to '....'
+
+**Expected results**
+
+A clear and concise description of what you expected to happen.
+
+**Actual results**
+
+A clear and concise description of what actually happened.
+
+**Additional details and attachments**
+
+If applicable, add any additional screenshots, logs, or other attachments to help explain your problem.
+
+**Versions**
+ - Deephaven: ...
+ - OS: ...
+ - Browser: ...
+ - Docker: ...

--- a/.github/ISSUE_TEMPLATES/epic.md
+++ b/.github/ISSUE_TEMPLATES/epic.md
@@ -1,0 +1,13 @@
+---
+name: Epic
+about: A large body of work that can be broken down into a number of feature requests
+labels: epic, triage
+title: "EPIC: "
+---
+
+<!-- Please read our Code of Conduct: https://github.com/deephaven/deephaven-core/blob/main/CODE_OF_CONDUCT.md -->
+<!-- Please search existing issues to avoid creating duplicates. -->
+
+[Description of body of work]
+
+<!-- After creation of the epic, create new Feature request issues and mention this epic to have them link. -->

--- a/.github/ISSUE_TEMPLATES/feature_request.md
+++ b/.github/ISSUE_TEMPLATES/feature_request.md
@@ -1,0 +1,12 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+labels: feature request, triage
+
+---
+
+<!-- Please read our Code of Conduct: https://github.com/deephaven/deephaven-core/blob/main/CODE_OF_CONDUCT.md -->
+<!-- Please search existing issues to avoid creating duplicates. -->
+
+<!-- Describe the feature you'd like. -->
+As a [user or stakeholder type], I want [some software feature] so that [some business value]

--- a/.github/ISSUE_TEMPLATES/feature_request.md
+++ b/.github/ISSUE_TEMPLATES/feature_request.md
@@ -1,7 +1,7 @@
 ---
 name: Feature request
 about: Suggest an idea for this project
-labels: feature request, triage
+labels: enhancement, triage
 
 ---
 


### PR DESCRIPTION
web-client-ui isn't using the templates yet. Should be able to remove these from deephaven-core after merged.
