### PR TITLE
Fix expired slack link

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -14,4 +14,4 @@ Explore some of our featured projects:
 
 ## Get support
 
-Have questions about contributing? Need help with Deephaven? Join us in our [slack channel](https://join.slack.com/t/deephavencommunity/shared_invite/zt-11x3hiufp-DmOMWDAvXv_pNDUlVkagLQ).
+Have questions about contributing? Need help with Deephaven? Join us in our [slack channel](https://deephaven.io/slack).


### PR DESCRIPTION
We recently learned slack invites can expire. Switch to a url we own that can manage re-directs.