### PR TITLE
Update versions in bug report

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -7,30 +7,49 @@ labels: bug, triage
 
 <!-- Please read our Code of Conduct: https://github.com/deephaven/deephaven-core/blob/main/CODE_OF_CONDUCT.md -->
 <!-- Please search existing issues to avoid creating duplicates. -->
+<!-- Use clear and concise text to keep the issue brief and to the point. -->
 
 **Description**
 
-A clear and concise description of what the bug is.
+<!-- Description of what the bug is. -->
 
 **Steps to reproduce**
+
+<!--
+A numbered set of steps to reproduce the issue, e.g.
+
 1. Go to '...'
 2. Click on '....'
 3. Scroll down to '....'
+-->
 
 **Expected results**
 
-A clear and concise description of what you expected to happen.
+<!-- 
+What you expected to happen. Index it by the steps to reproduce to make it clear, e.g.
+
+3. New page to load
+-->
 
 **Actual results**
 
-A clear and concise description of what actually happened.
+<!-- 
+What actually happened. Index it by the steps to reproduce to make it clear, e.g.
+
+3. New page did not load
+-->
 
 **Additional details and attachments**
 
-If applicable, add any additional screenshots, logs, or other attachments to help explain your problem.
+<!-- If applicable, add any additional screenshots, logs, or other attachments to help explain your problem. -->
 
 **Versions**
- - Deephaven: ...
+
+<!-- Version information. These versions can be copied from the Settings panel in the Deephaven UI. -->
+ - Engine Version: ...
+ - Web UI Version: ...
+ - Java Version: ...
+ - Barrage Version: ...
  - OS: ...
  - Browser: ...
  - Docker: ...


### PR DESCRIPTION
- Break down the different versions in the bug report. The UI now reports all these versions and they can be copied easily.
- Also made descriptions about each step commented out, so you don't have to delete each section, just fill in your new information.